### PR TITLE
Made it clear that value of WEBSITE_LOAD_CERTIFICATES needs to be an asterisk (*)

### DIFF
--- a/Documentation/Manual-Setup-Guide.md
+++ b/Documentation/Manual-Setup-Guide.md
@@ -376,7 +376,13 @@ You need at least the "BASIC" pricing plan, because you will need to upload the 
 
 ![Azure App Service - X.509 Certificate](./Figures/Fig-12-Azure-Web-App-03.png)
 
-After that, scroll a little bit to the "App Settings" section. There, you will have to configure a setting called *WEBSITE_LOAD_CERTIFICATES* with a value of *. In the following figure you can see a sample configuration. Alternatively through the new Azure Portal, you have to go to **"Application settings"**, scroll down to the **"App settings"** section and add the *WEBSITE_LOAD_CERTIFICATES* entry with a value of *. Click on **"Save"** at the top to confirm your modification.
+After that, scroll a little bit to the "App Settings" section. There, you will have to configure a setting called *WEBSITE_LOAD_CERTIFICATES* with a value of *
+
+In the following figure you can see a sample configuration. 
+
+Alternatively through the new Azure Portal, you have to go to **"Application settings"**, scroll down to the **"App settings"** section and add the *WEBSITE_LOAD_CERTIFICATES* entry with a value of *
+
+Click on **"Save"** at the top to confirm your modification.
 
 ![Azure App Service - SSL Certificates Setting](./Figures/Fig-13-Azure-Web-App-04.png)
 


### PR DESCRIPTION
It was not visible earlier in the GitHub flavored markdown. See the following image:

![image](https://cloud.githubusercontent.com/assets/173794/20325555/1cebf3c0-ab7d-11e6-8164-bd450c750c63.png)

This resulted in the app throwing errors such as _**Value cannot be null. Parameter name: certificate**_