### PR TITLE
Updated SubSiteProvisioningJobHandler.cs

### DIFF
--- a/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.Infrastructure/Jobs/Handlers/SubSiteProvisioningJobHandler.cs
+++ b/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.Infrastructure/Jobs/Handlers/SubSiteProvisioningJobHandler.cs
@@ -106,8 +106,11 @@ namespace OfficeDevPnP.PartnerPack.Infrastructure.Jobs.Handlers
                         }
 
                         // Fixup Title and Description
-                        template.WebSettings.Title = job.SiteTitle;
-                        template.WebSettings.Description = job.Description;
+                        if (template.WebSettings != null) 
+                        {
+                            template.WebSettings.Title = job.SiteTitle;
+                            template.WebSettings.Description = job.Description;
+                        }
 
                         // Apply the template to the target site
                         web.ApplyProvisioningTemplate(template, ptai);
@@ -139,11 +142,17 @@ namespace OfficeDevPnP.PartnerPack.Infrastructure.Jobs.Handlers
                             {
                                 var brandingTemplate = BrandingJobHandler.PrepareBrandingTemplate(repositoryContext, brandingSettings);
 
-                                // Fixup Title and Description
-                                brandingTemplate.WebSettings.Title = job.SiteTitle;
-                                brandingTemplate.WebSettings.Description = job.Description;
+                                if(brandingTemplate != null)
+                                {
+                                    if(brandingTemplate.WebSettings != null)
+                                    {
+                                        // Fixup Title and Description
+                                        brandingTemplate.WebSettings.Title = job.SiteTitle;
+                                        brandingTemplate.WebSettings.Description = job.Description;
 
-                                BrandingJobHandler.ApplyBrandingOnWeb(web, brandingSettings, brandingTemplate);
+                                        BrandingJobHandler.ApplyBrandingOnWeb(web, brandingSettings, brandingTemplate);
+                                    }
+                                }
                             }
                         }
 


### PR DESCRIPTION
Fixed error same as of SiteCollectionsBatchJobHandler.cs
The error was of not handeling WebSettings null value.

Because of this, Subsite gets created but due to empty template no websetting defined, it gives

`Exception` occurred: Object reference not set to an instance of an object.
[01/04/2017 13:01:29 > 17cf59: INFO] Stack Trace:
[01/04/2017 13:01:29 > 17cf59: INFO]    at OfficeDevPnP.PartnerPack.Infrastructure.Jobs.Handlers.SubSiteProvisioningJobHandler.CreateSubSite(SubSiteProvisioningJob job)
[01/04/2017 13:01:29 > 17cf59: INFO]    at OfficeDevPnP.PartnerPack.Infrastructure.Jobs.Handlers.SubSiteProvisioningJobHandler.RunJobInternal(ProvisioningJob job)
[01/04/2017 13:01:29 > 17cf59: INFO]    at OfficeDevPnP.PartnerPack.Infrastructure.Jobs.Handlers.ProvisioningJobHandler.RunJob(ProvisioningJob job)`