### PR TITLE
Fixed spelling mistake in logging. "Applyed" to "Applied"

### DIFF
--- a/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.Infrastructure/Jobs/Handlers/SiteCollectionProvisioningJobHandler.cs
+++ b/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.Infrastructure/Jobs/Handlers/SiteCollectionProvisioningJobHandler.cs
@@ -231,7 +231,7 @@ namespace OfficeDevPnP.PartnerPack.Infrastructure.Jobs.Handlers
                         }
 
 
-                        Console.WriteLine("Applyed Provisioning Template \"{0}\" to site.",
+                        Console.WriteLine("Applied Provisioning Template \"{0}\" to site.",
                             job.ProvisioningTemplateUrl);
                     }
                 }

--- a/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.Infrastructure/Jobs/Handlers/SubSiteProvisioningJobHandler.cs
+++ b/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.Infrastructure/Jobs/Handlers/SubSiteProvisioningJobHandler.cs
@@ -166,7 +166,7 @@ namespace OfficeDevPnP.PartnerPack.Infrastructure.Jobs.Handlers
                             }
                         }
 
-                        Console.WriteLine("Applyed Provisioning Template \"{0}\" to site.",
+                        Console.WriteLine("Applied Provisioning Template \"{0}\" to site.",
                             job.ProvisioningTemplateUrl);
                     }
                 }


### PR DESCRIPTION
Updated logging text to fix spelling mistake of "Applied".