### PR TITLE
enable PnP Provisioning logs on azure web job logs

### DIFF
--- a/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.ContinousJob/App.config
+++ b/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.ContinousJob/App.config
@@ -98,4 +98,14 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <system.diagnostics>
+    <sharedListeners>
+      <add type="System.Diagnostics.ConsoleTraceListener" name="console" />
+    </sharedListeners>
+    <trace autoflush="true" indentsize="0">
+      <listeners>
+        <add name="console" />
+      </listeners>
+    </trace>
+  </system.diagnostics>
 </configuration>

--- a/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.Infrastructure/Diagnostics/RemoveWordsFilter.cs
+++ b/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.Infrastructure/Diagnostics/RemoveWordsFilter.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Diagnostics;
+
+namespace OfficeDevPnP.PartnerPack.Infrastructure.Diagnostics
+{
+    /// <summary>
+    /// Class to filter entries which contains some given words on Trace Listener
+    /// </summary>
+    public class RemoveWordsFilter : TraceFilter
+    {
+
+        public RemoveWordsFilter(String[] words)
+        {
+            _words = words;
+        }
+
+        public String[] _words { get; set; }
+
+        override public bool ShouldTrace(TraceEventCache cache, string source,
+            TraceEventType eventType, int id, string formatOrMessage,
+            object[] args, object data, object[] dataArray)
+        {
+            if (formatOrMessage == null) return false;
+            foreach (string word in _words)
+            {
+                if (formatOrMessage.Contains(word))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+}

--- a/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.Infrastructure/OfficeDevPnP.PartnerPack.Infrastructure.csproj
+++ b/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.Infrastructure/OfficeDevPnP.PartnerPack.Infrastructure.csproj
@@ -232,6 +232,7 @@
       <DependentUpon>PnPPartnerPackConfiguration.xsd</DependentUpon>
     </Compile>
     <Compile Include="Configuration\PnPPartnerPackConfigurationSectionHandler.cs" />
+    <Compile Include="Diagnostics\RemoveWordsFilter.cs" />
     <Compile Include="HttpHelper.cs" />
     <Compile Include="IConfigurable.cs" />
     <Compile Include="IProvisioningRepository.cs" />


### PR DESCRIPTION
- Add RemoveWordsFilter to filter Trace (there are tons of TokenCache logs)
- Add TextWriterTraceListener to connect TextWriter log with Trace object.
- Remove the TextWriterTraceListener object after run ProcessQueueMessage

More info: https://blog.josequinto.com/2017/02/16/enable-azure-invocation-log-at-a-web-job-function-level-for-pnp-provisioning/