### PR TITLE
Site collection creation fixed and setup guide updated

### DIFF
--- a/Documentation/Manual-Setup-Guide.md
+++ b/Documentation/Manual-Setup-Guide.md
@@ -141,7 +141,7 @@ your tenant. Click the "Add" button in the upper left part of the blade, this wi
 
 ![Azure AD - Add an Application - First Step](./Figures/Fig-08-Azure-AD-Add-Application-Step-01.png)
 
-Then, provide a **name** for your application (we suggest to name it "SharePoint PnP Partner Pack"), select the option **"Web app / API"**, and fill in the **"Sign-on URL"** with the **URL** of the Azure App Service that you created before. Click create when done.
+Then, provide a **name** for your application (we suggest to name it "SharePoint PnP Partner Pack"), select the option **"Web app / API"**, and fill in the **"Sign-on URL"** with the **URL** of the Azure App Service that you created before. Make sure to use a forward slash at the end of the URL (otherwise you will get a 'reply address does not match error'). Click create when done.
 
 The newly created app registration will now be listed in your "App Registrations" list.
 Open it and then click into settings and then Properties.  You should now be at the following screen: 
@@ -153,7 +153,7 @@ Please make sure you :
 - Upload the Application logo
 - Press save. 
 
-Now, you should go back to the settings blade. Go into **Keys** where you'll create a Client Secret. In order to do that, add a new security key (selecting 1 year or 2 years for key duration). Press the "Save" button in the lower part of the screen to generate the key value. After saving, you will see the key value. **Copy it in a safe place**, because you will not see it anymore.
+Now, you should go back to the settings blade. Go into **Keys** where you'll create a Client Secret (used for app-only authentication). In order to do that, add a new security key (selecting 1 year, 2 years or never expires for key duration). Press the "Save" button in the lower part of the screen to generate the key value. After saving, you will see the key value. **Copy it in a safe place**, because you will not see it anymore.
 
 ![Azure AD - Create a client Secret](./Figures/Fig-10-Azure-AD-Add-AplicationSecret.png)
 
@@ -178,6 +178,9 @@ You need to configure the following permissions:
 ![Azure AD - Application Configuration - Permissions Blade](./Figures/Fig-12-Azure-AD-App-Config-03.png)
 
 The "Application Permissions" are those granted to the application when running as App Only. The other set of permissions, called "Delegated Permissions", defines the permissions granted to the application when running under a specific user's account delegation (using an app and user access token, from an OAuth 2.0 perspective).
+
+Click the Grant Permission button on the 'Required Permissions' tab, if you want to give non-tenant admin users access to the application.
+
 <!--
 ![Azure AD - Application Configuration - Client Secret](./Figures/Fig-06-Azure-AD-App-Config-01.png)
 -->
@@ -435,7 +438,7 @@ Moreover, you will have to publish them into the Azure App Service. To provision
 
 > For further details about how to publish Azure Web Jobs you can be read the following article: <a href="https://azure.microsoft.com/en-gb/documentation/articles/websites-dotnet-deploy-webjobs/">Deploy WebJobs using Visual Studio</a>.
 
-#### Publishing the **ScheduledJob** using a **minute** schedule
+#### Publishing the **ScheduledJob** using a **minute** schedule (Azure Scheduler)
 When you publish a Web Job that requires to be run at a schedule, your web job by default will end up in a free scheduler job collection which only allows to run scheduled jobs at a 1 hour interval or higher. Since site collection creation is handled via the ScheduledJob you might want to have this job running more frequently (e.g. every 5 minutes). Below steps describe how you can convert the created scheduled job collection to a paying version, which allows to schedule jobs at a minute level interval:
 * Deploy the **ScheduledJob** at a 1 hour interval. This will allow the job to get properly scheduled
 * Go to the [Azure management portal](http://portal.azure.com) (portal.azure.com), click on "Browse >" and select **"Scheduler Job Collections"**
@@ -453,5 +456,21 @@ Below screenshots show some of the above steps in action:
 
 ![](http://i.imgur.com/UR5TsF3.png)
 
+#### Publishing the **ScheduledJob** using a **minute** schedule (Internal WebJob Scheduler)
+Instead of deploying the ScheduledJob to a Schedule Job Collection (Azure Scheduler) you can deploy it directly to the app service you created earlier (Interal WebJob Scheduler) for the PnP Partner Pack web site. The only caveat is that this requires your app service to be configured as Always On (more expensive!). Otherwise the ScheduledJob will stop running after 12 hours.
+
+In the root of the ScheduledJob Visual Studio project, add a JSON file called settings.job. Make sure it is set to 'Copy always' in the file properties. The schedule is specified with a cron expression composed of the following fields: {second} {minute} {hour} {day} {month} {day of the week}. The settings.job for a minute schedule looks like this:  
+
+```
+{
+  "schedule": "0 * * * * *"
+}
+```
+
+Also, in the webjob-publish-settings.json file (under Properties in the Visual Studio project) you want to change the runMode from 'OnDemand' to 'Scheduled'.
+
+Finally, deploy the web job from Visual Studio using the 'Publish as Azure WebJob' function.
+
+> For further details about how to use cron expressions with WebJobs you can be read the following article: <a href="http://blog.amitapple.com/post/2015/06/scheduling-azure-webjobs/">Scheduling Azure WebJobs with cron expressions</a>.
 
 <img src="https://telemetry.sharepointpnp.com/pnp-partner-pack/documentation/manual-setup-guide" /> 

--- a/Documentation/Manual-Setup-Guide.md
+++ b/Documentation/Manual-Setup-Guide.md
@@ -66,7 +66,7 @@ To create a self signed certificate with this script:
 You will be asked to provide a password to encrypt your private key, and both the .PFX file and .CER file will be exported to the current folder.
 
 #### Using makecert (alternative manual option)
-Alternatively, if you have Microsoft Visual Studio 2013/2015 installed on your enviroment, you already have the [makecert tool](https://msdn.microsoft.com/library/windows/desktop/aa386968.aspx), as well. Otherwise, you will have to download from MSDN and to install the Windows SDK for your current version of Windows Operating System.
+Alternatively, if you have Microsoft Visual Studio 2013/2015 installed on your environment, you already have the [makecert tool](https://msdn.microsoft.com/library/windows/desktop/aa386968.aspx), as well. Otherwise, you will have to download from MSDN and to install the Windows SDK for your current version of Windows Operating System.
 
 The command for creating a new self-signed X.509 certificate is the following one:
 
@@ -89,7 +89,7 @@ Go Back to the new Azure Portal, and find **Storage Accounts** menu option. You 
 
 ![Azure AD - Storage Account- Create](./Figures/Fig-01-StorageAccount-01.png)
 
-After having created the Azure Blob Storage account, open the "Manage Access Keys" popup screen and copy the values of **"Storage Account Name"**, and **"Primary Access Key"**. Alternatively if using the new Azure Portal, click on your Storage account, click on **"Accss keys"** under the Settings header and copy out the **"Storage account name"** and **"key1"** values.
+After having created the Azure Blob Storage account, open the "Manage Access Keys" popup screen and copy the values of **"Storage Account Name"**, and **"Primary Access Key"**. Alternatively if using the new Azure Portal, click on your Storage account, click on **"Access keys"** under the Settings header and copy out the **"Storage account name"** and **"key1"** values.
 
 ![Azure AD - Storage Account- Create](./Figures/Fig-02-StorageAccount-02-Keys.png)
 
@@ -149,8 +149,8 @@ Open it and then click into settings and then Properties.  You should now be at 
 ![Azure AD - Add an Application - Third Step](./Figures/Fig-09-Azure-AD-Add-Application-Step-02.png)
 
 Please make sure you :
-- Copy the **Aplication ID** value as you'll need it later.
-- Upload the Application logo
+- Copy the **Application ID** value as you'll need it later.
+- Upload the Application logo (location: OfficeDevPnP.PartnerPack.SiteProvisioning\PnP-O365-App-Icon.png)
 - Press save. 
 
 Now, you should go back to the settings blade. Go into **Keys** where you'll create a Client Secret (used for app-only authentication). In order to do that, add a new security key (selecting 1 year, 2 years or never expires for key duration). Press the "Save" button in the lower part of the screen to generate the key value. After saving, you will see the key value. **Copy it in a safe place**, because you will not see it anymore.
@@ -405,7 +405,7 @@ All the values surrounded by [name] have to be replaced with the corresponding v
 Upload the Web application to the target Azure App Service. You can use any of the available techniques for doing that (GitHub repository, FTP, Visual Studio Publish, etc.). 
 
 **Important:**
-When you publish the web application using Microsoft Visual Studio, remember to **uncheck **the option "Enable Organizational Authentication". If you leave this selected you migh face authentication issues when running the PnP Partner Pack.
+When you publish the web application using Microsoft Visual Studio, remember to **uncheck **the option "Enable Organizational Authentication". If you leave this selected you might face authentication issues when running the PnP Partner Pack.
 
 Notice that the web application uses a token cache for ADAL tokens, which are used when accessing the Microsoft Graph API. The token cache provided is based on the web application session. Thus, it is not a scalable solution and it cannot be used with multiple instances of the web app. However, you can configure a session based on an external persistence provider, like for example the <a href="https://azure.microsoft.com/en-us/documentation/articles/cache-asp.net-session-state-provider/">Azure Redis Cache</a>, or you can define a token cache handler of your own, using a backend database or whatever else. For further details about ADAL and the token cache, you can read the <a href="./Architecture-and-Implementation.md">architectural document</a> related to the PnP Partner Pack.
  
@@ -461,13 +461,22 @@ Instead of deploying the ScheduledJob to a Schedule Job Collection (Azure Schedu
 
 In the root of the ScheduledJob Visual Studio project, add a JSON file called settings.job. Make sure it is set to 'Copy always' in the file properties. The schedule is specified with a cron expression composed of the following fields: {second} {minute} {hour} {day} {month} {day of the week}. The settings.job for a minute schedule looks like this:  
 
-```
+```JSON
 {
   "schedule": "0 * * * * *"
 }
 ```
 
-Also, in the webjob-publish-settings.json file (under Properties in the Visual Studio project) you want to change the runMode from 'OnDemand' to 'Scheduled'.
+Also, in the webjob-publish-settings.json file (under Properties in the Visual Studio project) you want to change the runMode from 'OnDemand' to 'Scheduled' and give it at start date. You will end up with a file looking like this:
+
+```JSON
+{
+  "$schema": "http://schemastore.org/schemas/json/webjob-publish-settings.json",
+  "webJobName": "ScheduledJob",
+  "startTime": "2016-12-18T00:00:00-08:00",
+  "runMode": "Scheduled"
+}
+```
 
 Finally, deploy the web job from Visual Studio using the 'Publish as Azure WebJob' function.
 

--- a/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.Infrastructure/Jobs/Handlers/SiteCollectionProvisioningJobHandler.cs
+++ b/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.Infrastructure/Jobs/Handlers/SiteCollectionProvisioningJobHandler.cs
@@ -56,7 +56,7 @@ namespace OfficeDevPnP.PartnerPack.Infrastructure.Jobs.Handlers
                         // Configure the Site Collection properties
                         SiteEntity newSite = new SiteEntity();
                         newSite.Description = job.Description;
-                        newSite.Lcid = (uint)job.Language;
+                        newSite.Lcid = (uint) job.Language;
                         newSite.Title = job.SiteTitle;
                         newSite.Url = siteUrl;
                         newSite.SiteOwnerLogin = job.PrimarySiteCollectionAdmin;
@@ -65,9 +65,9 @@ namespace OfficeDevPnP.PartnerPack.Infrastructure.Jobs.Handlers
 
                         // Use the BaseSiteTemplate of the template, if any, otherwise 
                         // fallback to the pre-configured site template (i.e. STS#0)
-                        newSite.Template = !String.IsNullOrEmpty(template.BaseSiteTemplate) ?
-                            template.BaseSiteTemplate :
-                            PnPPartnerPackSettings.DefaultSiteTemplate;
+                        newSite.Template = !String.IsNullOrEmpty(template.BaseSiteTemplate)
+                            ? template.BaseSiteTemplate
+                            : PnPPartnerPackSettings.DefaultSiteTemplate;
 
                         newSite.TimeZoneId = job.TimeZone;
                         newSite.UserCodeMaximumLevel = job.UserCodeMaximumLevel;
@@ -76,7 +76,13 @@ namespace OfficeDevPnP.PartnerPack.Infrastructure.Jobs.Handlers
                         // Create the Site Collection and wait for its creation (we're asynchronous)
                         var tenant = new Tenant(adminContext);
                         tenant.CreateSiteCollection(newSite, true, true); // TODO: Do we want to empty Recycle Bin?
+                    }
 
+                    // Work-around for the error 'Operation is not valid due to the current state of the object' (since DEC 2016)
+                    // Get fresh Tenant instance after site collection was initially created.
+                    using (var adminContext = PnPPartnerPackContextProvider.GetAppOnlyTenantLevelClientContext())
+                    {
+                        var tenant = new Tenant(adminContext);
                         Site site = tenant.GetSiteByUrl(siteUrl);
                         Web web = site.RootWeb;
 

--- a/scripts/Provision-InfrastructureSiteArtifacts.ps1
+++ b/scripts/Provision-InfrastructureSiteArtifacts.ps1
@@ -56,40 +56,40 @@ $siteHost = $siteHost.Replace(".sharepoint.com","-admin.sharepoint.com")
 $siteHost = $siteHost.Trim('/')
 
 Connect-SPOnline -Url "https://$siteHost" -Credentials $Credentials
-$infrastructureSiteInfo = Get-SPOTenantSite -Url $InfrastructureSiteUrl -ErrorAction SilentlyContinue
+$infrastructureSiteInfo = Get-PnPTenantSite -Url $InfrastructureSiteUrl -ErrorAction SilentlyContinue
 if($InfrastructureSiteInfo -eq $null)
 {
-    Write-Host -ForegroundColor Cyan "Infrastructure Site does not exist. Please create site collection first through the UI, or use New-SPOTenantSite"
+    Write-Host -ForegroundColor Cyan "Infrastructure Site does not exist. Please create site collection first through the UI, or use New-PnPTenantSite"
 } else {
     Connect-SPOnline -Url $InfrastructureSiteUrl -Credentials $Credentials
-    Apply-SPOProvisioningTemplate -Path "$basePath\Templates\Infrastructure\PnP-Partner-Pack-Infrastructure-Jobs.xml"
-    Apply-SPOProvisioningTemplate -Path "$basePath\Templates\Infrastructure\PnP-Partner-Pack-Infrastructure-Templates.xml"
+    Apply-PnPProvisioningTemplate -Path "$basePath\Templates\Infrastructure\PnP-Partner-Pack-Infrastructure-Jobs.xml"
+    Apply-PnPProvisioningTemplate -Path "$basePath\Templates\Infrastructure\PnP-Partner-Pack-Infrastructure-Templates.xml"
 
     # Unhide the 2 infrastructure lists
-    $l = Get-SPOList "PnPProvisioningTemplates"
+    $l = Get-PnPList "PnPProvisioningTemplates"
     $l.Hidden = $false
     $l.OnQuickLaunch = $true
     $l.Update()
-    Execute-SPOQuery
+    Execute-PnPQuery
 
-    $l = Get-SPOList "PnPPRovisioningJobs"
+    $l = Get-PnPList "PnPPRovisioningJobs"
     $l.Hidden = $false
     $l.OnQuickLaunch = $true
     $l.Update()
-    Execute-SPOQuery
+    Execute-PnPQuery
     
-    Apply-SPOProvisioningTemplate $basePath\Templates\PnP-Partner-Pack-Infrastructure-Contents.xml
+    Apply-PnPProvisioningTemplate $basePath\Templates\PnP-Partner-Pack-Infrastructure-Contents.xml
 
 	
     # Due to an issue in core, we have to loop through the items in the provisioning template list and set the correct content type
     # Find the content type in the list
-    $ctx = Get-SPOContext
-    $l = Get-SPOList "PnPProvisioningTemplates"
+    $ctx = Get-PnPContext
+    $l = Get-PnPList "PnPProvisioningTemplates"
     $ctx.Load($l.ContentTypes)
-    Execute-SPOQuery
+    Execute-PnPQuery
     $ct = $l.ContentTypes | ?{$_.Name -eq "PnpProvisioningTemplate"}
 
-    $items = Get-SPOListItem -List "PnPProvisioningTemplates" -Fields "FileLeafRef"
+    $items = Get-PnPListItem -List "PnPProvisioningTemplates" -Fields "FileLeafRef"
     foreach($item in $items)
     {
 	$filename = $item["FileLeafRef"]
@@ -98,7 +98,7 @@ if($InfrastructureSiteInfo -eq $null)
 		Write-Host -ForeGroundColor DarkGray "Setting content type on $filename"
 		$item["ContentTypeId"] = $ct.Id
 		$item.Update()
-		Execute-SPOQuery
+		Execute-PnPQuery
 	}
     }
     


### PR DESCRIPTION
Site collection creation fixed:
On some tenants/in some cases the creation of new site collection fails with the error 'Operation is not valid due to the current state of the object'. More info [here](https://techcommunity.microsoft.com/t5/SharePoint-Developer/SharePoint-Online-issues-creating-site-collections-via-PnP-code/m-p/47652). Work-around implemented in SiteCollectionProvisioningJobHandler.

Updates to setup guide: 
Section on Internal WebJob Scheduler added, minor improvements to AAD configuration and some typos fixed.

PowerShell prefixes:
Changed the deprecated (-SPO) prefix to the new (-PnP) prefix for PnP command-lets in setup scripts.