### PR TITLE
Added UserPrincipalName and DisplayName to Personacard

### DIFF
--- a/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.SiteProvisioning/Scripts/custom.principals.js
+++ b/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.SiteProvisioning/Scripts/custom.principals.js
@@ -79,7 +79,12 @@ function searchPeopleOrGroups(searchId, searchName, searchGroups, maxSelection) 
                         $(li).append(div);
 
                         var mail = e.Mail;
-
+                        var upn = e.UserPrincipalName;
+                        var displayName = e.DisplayName;
+                        if (e.FirstName != null && e.LastName != null) {
+                            displayName = e.FirstName + " " + e.LastName;
+                        }
+                        
                         $(li).click(function (e) {
                             var currentSelected = $("#" + searchId + " ul[class=ms-PeoplePicker-selectedPeople] > li").length;
                             if (currentSelected >= maxSelection) {
@@ -105,7 +110,9 @@ function searchPeopleOrGroups(searchId, searchName, searchGroups, maxSelection) 
                             var ul = $("#" + searchId + " ul[class = ms-PeoplePicker-selectedPeople]");
                             var count = $("li", ul).length;
                             selectedLi.append($("<input type=hidden name=" + searchName + ".Principals[" + count + "].Mail />").val(mail));
-
+                            selectedLi.append($("<input type=hidden name=" + searchName + ".Principals[" + count + "].UserPrincipalName />").val(upn));
+                            selectedLi.append($("<input type=hidden name=" + searchName + ".Principals[" + count + "].DisplayName />").val(displayName));
+                            
                             $("#" + searchId + " .ms-PeoplePicker-selectedCount").text(count + 1);
 
                             ul.append(selectedLi);

--- a/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.SiteProvisioning/Views/Shared/EditorTemplates/Principals.cshtml
+++ b/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.SiteProvisioning/Views/Shared/EditorTemplates/Principals.cshtml
@@ -49,6 +49,8 @@
                                 </div>
                                 <button class="ms-PeoplePicker-resultAction js-selectedRemove"><i class="ms-Icon ms-Icon--x"></i></button>
                                 @Html.HiddenFor(m => Model.Principals[x].Mail)
+                                @Html.HiddenFor(m => Model.Principals[x].DisplayName)
+                                @Html.HiddenFor(m => Model.Principals[x].UserPrincipalName)
                             </li>
                         }
                     }


### PR DESCRIPTION
After errors in the validation of a new Site Collection form, the selected persona cards of first and second site collection administrator fields become invisible. Adding UserPrincipalName and DisplayName solves this problem.