### PR TITLE
Clone subsite context pointing to the right sub web

### DIFF
--- a/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.Infrastructure/Jobs/Handlers/SubSiteProvisioningJobHandler.cs
+++ b/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.Infrastructure/Jobs/Handlers/SubSiteProvisioningJobHandler.cs
@@ -71,6 +71,14 @@ namespace OfficeDevPnP.PartnerPack.Infrastructure.Jobs.Handlers
                         Web web = parentWeb.Webs.Add(newWeb);
                         context.ExecuteQueryRetry();
 
+                        if (template.ExtensibilityHandlers.Any())
+                        {
+                            // Clone Context pointing to Sub Site (needed for calling custom Extensibility Providers from the pnp template passing the right ClientContext)
+                            string newWeburl = web.EnsureProperty(w => w.Url);
+                            ClientContext webClientContext = context.Clone(newWeburl);
+                            web = webClientContext.Web;
+                        }
+
                         // Create sub-web unique groups
                         if (!job.InheritPermissions)
                         {


### PR DESCRIPTION
Setting the right ClientContext when a new Web is created (Context pointing to the new sub web created). Without this, if your template has a custom Extensibility Provider, it will receive the wrong ClientContext (pointing to the parent Site collection, instead to the new sub web).